### PR TITLE
Fix publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -32,7 +32,7 @@ description:
     features:
       - ricerca pratiche USR per codice fiscale del cittadino intestatario
       - ricerca pratiche USR per partita iva dell'impresa appaltatrice
-    genericName: Pratiche presentate U.S.R. - ricostruzione post sisma 2016
+    genericName: Pratiche presentate U.S.R. 
     longDescription: >
       Le pagine rendono disponibili i dati relativi alle pratiche presentate presso gli Uffici di ricostruzione(Usr) in merito alle  Ordinanze:
 
@@ -55,7 +55,7 @@ description:
       del sistema informativo DOMUS di Regione Marche, sintetizzati in una vista
       e presentati in formato tabellare.
     shortDescription: >-
-    Ricerca pratiche USR con presentazione dei relativi dat e documenti pubblici, processi delle PA coinvolte e stato di avanzamento.
+      Ricerca pratiche USR con presentazione dei relativi dat e documenti pubblici, processi delle PA coinvolte e stato di avanzamento.
     screenshots:
       - doc/screenshots/Screen_1.png
       - doc/screenshots/Screen_2.png


### PR DESCRIPTION
Questa PR:
* corregge un'indentazione;
* accorcia il nome generico (max 35 caratteri supportati).

Per curiosità, sono modifiche che avete apportato a mano oppure tale file è stato generato direttamente dal nostro editor? Per capire se si tratta di un bug lato nostro oppure è stata semplicemente una svista in fase di compilazione manuale. 
Grazie molte per la disponibilità.
Resto a disposizione
@sergio-villarreal 
Fixes #1 